### PR TITLE
Add pre-processor directives #if defined (USB_DRD_FS) and #endif into stm32g0xx_hal_hcd.c/h

### DIFF
--- a/Drivers/STM32G0xx_HAL_Driver/Inc/stm32g0xx_hal_hcd.h
+++ b/Drivers/STM32G0xx_HAL_Driver/Inc/stm32g0xx_hal_hcd.h
@@ -28,7 +28,7 @@ extern "C" {
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g0xx_ll_usb.h"
 
-
+#if defined (USB_DRD_FS)
 /** @addtogroup STM32G0xx_HAL_Driver
   * @{
   */
@@ -481,13 +481,13 @@ HAL_StatusTypeDef  HAL_HCD_PMAReset(HCD_HandleTypeDef *hhcd);
   */
 /* Private functions prototypes ----------------------------------------------*/
 
- /**
+/**
   * @}
   */
- /**
+/**
   * @}
   */
-
+#endif /* defined (USB_DRD_FS) */
 
 #ifdef __cplusplus
 }

--- a/Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_hcd.c
+++ b/Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_hcd.c
@@ -58,8 +58,7 @@
   */
 
 #ifdef HAL_HCD_MODULE_ENABLED
-
-
+#if defined (USB_DRD_FS)
 
 /** @defgroup HCD HCD
   * @brief HCD HAL module driver
@@ -2492,7 +2491,7 @@ static HAL_StatusTypeDef  HAL_HCD_PMAFree(HCD_HandleTypeDef *hhcd, uint32_t pma_
 /**
   * @}
   */
-
+#endif /* defined (USB_DRD_FS) */
 #endif /* HAL_HCD_MODULE_ENABLED */
 
 /**


### PR DESCRIPTION
Add pre-processor directives #if defined (USB_DRD_FS) and #endif into stm32g0xx_hal_hcd.c/h

Rationale: Avoid compilation errors when using targets not supporting USB DRD FS.