### PR TITLE
Set default Vector Table location

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32G0xx/Source/Templates/system_stm32g0xx.c
+++ b/Drivers/CMSIS/Device/ST/STM32G0xx/Source/Templates/system_stm32g0xx.c
@@ -119,6 +119,22 @@
 #if defined(USER_VECT_TAB_ADDRESS)
 /*!< Uncomment the following line if you need to relocate your vector Table
      in Sram else user remap will be done in Flash. */
+/* #define USER_VECT_TAB_SRAM */
+#if defined(USER_VECT_TAB_SRAM)
+#define USER_VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#define USER_VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
+#else
+#define USER_VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#define USER_VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
+#endif /* USER_VECT_TAB_SRAM */
+#else
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done in Flash. */
 /* #define VECT_TAB_SRAM */
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
@@ -186,7 +202,9 @@ void SystemInit(void)
 {
   /* Configure the Vector Table location -------------------------------------*/
 #if defined(USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation */
+  SCB->VTOR = USER_VECT_TAB_BASE_ADDRESS | USER_VECT_TAB_OFFSET; /* User Vector Table Relocation */
+#else
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Default Vector Table Relocation */
 #endif /* USER_VECT_TAB_ADDRESS */
 }
 


### PR DESCRIPTION
If User doesn't define USER_VECT_TAB_ADDRESS, Vector Table will never be set with current SystemInit() function. Interrupts won't work with such configuration.

Added #else option if User doesn't want to use own VTOR - just set the
default.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeG0/blob/master/CONTRIBUTING.md) file.
